### PR TITLE
Add output timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ $ python -m benchmark.bench load \
 2023-10-19 18:21:06 INFO     using shape profile balanced: context tokens: 500, max tokens: 500
 2023-10-19 18:21:06 INFO     warming up prompt cache
 2023-10-19 18:21:06 INFO     starting load...
-time: 10   rpm: 1.0   requests: 1     failures: 0    throttled: 0    ctx tpm: 501.0  gen tpm: 103.0  ttft avg: 0.736  ttft 95th: n/a    tbt avg: 0.088  tbt 95th: n/a    e2e avg: 1.845  e2e 95th: n/a    util avg: 0.0%   util 95th: n/a   
-time: 11   rpm: 5.0   requests: 5     failures: 0    throttled: 0    ctx tpm: 2505.0 gen tpm: 515.0  ttft avg: 0.937  ttft 95th: 1.321  tbt avg: 0.042  tbt 95th: 0.043  e2e avg: 1.223 e2e 95th: 1.658 util avg: 0.8%   util 95th: 1.6%  
-time: 12   rpm: 8.0   requests: 8     failures: 0    throttled: 0    ctx tpm: 4008.0 gen tpm: 824.0  ttft avg: 0.913  ttft 95th: 1.304  tbt avg: 0.042  tbt 95th: 0.043  e2e avg: 1.241 e2e 95th: 1.663 util avg: 1.3%   util 95th: 2.6% 
+2023-10-19 18:21:06 rpm: 1.0   requests: 1     failures: 0    throttled: 0    ctx tpm: 501.0  gen tpm: 103.0  ttft avg: 0.736  ttft 95th: n/a    tbt avg: 0.088  tbt 95th: n/a    e2e avg: 1.845  e2e 95th: n/a    util avg: 0.0%   util 95th: n/a   
+2023-10-19 18:21:07 rpm: 5.0   requests: 5     failures: 0    throttled: 0    ctx tpm: 2505.0 gen tpm: 515.0  ttft avg: 0.937  ttft 95th: 1.321  tbt avg: 0.042  tbt 95th: 0.043  e2e avg: 1.223 e2e 95th: 1.658 util avg: 0.8%   util 95th: 1.6%  
+2023-10-19 18:21:08 rpm: 8.0   requests: 8     failures: 0    throttled: 0    ctx tpm: 4008.0 gen tpm: 824.0  ttft avg: 0.913  ttft 95th: 1.304  tbt avg: 0.042  tbt 95th: 0.043  e2e avg: 1.241 e2e 95th: 1.663 util avg: 1.3%   util 95th: 2.6% 
 ```
 
 **Load test with custom request shape**

--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -8,7 +8,7 @@ from .tokenizecmd import tokenize
 from .loadcmd import load
 
 def main():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
     parser = argparse.ArgumentParser(description="Benchmarking tool for Azure OpenAI Provisioned Throughput Units (PTUs).")
     sub_parsers = parser.add_subparsers()


### PR DESCRIPTION
Output timestamp for human format and include it as a json field for jsonl:
```
2023-10-31 01:00:54 rpm: 5.0   requests: 5     failures: 0    throttled: 0    ctx_tpm: 2500.0 gen_tpm: 515.0  ttft_avg: 0.82   ttft_95th: 1.296  tbt_avg: 0.047  tbt_95th: 0.048  e2e_avg: 5.619  e2e_95th: 6.212  util_avg: 99.4%  util_95th: 99.9%
```

```jsonl
{"run_seconds": 6, "timestamp": "2023-10-31 01:06:08", "rpm": 4.0, "requests": 4, "failures": 0, "throttled": 0, "tpm": {"context": 2004.0, "gen": 412.0}, "e2e": {"avg": 3.971, "95th": 4.274}, "ttft": {"avg": 1.181, "95th": 1.221}, "tbt": {"avg": 0.027, "95th": 0.03}, "util": {"avg": "57.6%", "95th": "58.7%"}}
```

fixes #4 