### PR TITLE
Change prompt to allow for longer generations

### DIFF
--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -162,7 +162,7 @@ def _generate_messages(model:str, tokens:int, max_tokens:int=None) -> ([dict], i
       r = wonderwords.RandomWord()
       messages = [{"role":"user", "content":str(time.time()) + " "}]
       if max_tokens is not None:
-         messages.append({"role":"user", "content":str(time.time()) + f" write an essay in at least {max_tokens*3} words"})
+         messages.append({"role":"user", "content":str(time.time()) + f" write a long essay about life in at least {max_tokens} tokens"})
       messages_tokens = 0
 
       if len(CACHED_PROMPT) > 0:


### PR DESCRIPTION
Slightly change the prompt to have the model to do full generation in case of larger requested `max_tokens`.

@michaeltremeer
