### PR TITLE
Emit a warning when request e2e latency > aggregation-window

### DIFF
--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -102,8 +102,8 @@ class _StatsAggregator(threading.Thread):
             self.request_latency._append(stats.request_start_time, request_latency)
             if request_latency > self.window_duration:
                logging.warning((
-                     f"request completed in {math.ceil(request_latency)} seconds, while aggregation-window is {int(self.window_duration)} "
-                     "seconds. Consider increasing aggregation-window to at least 2x your typical request latency."
+                     f"request completed in {round(request_latency, 2)} seconds, while aggregation-window is {round(self.window_duration, 2)} "
+                     "seconds, consider increasing aggregation-window to at least 2x your typical request latency."
                   )
                )   
             self.request_timestamps._append(stats.request_start_time, stats.request_start_time)

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -102,8 +102,8 @@ class _StatsAggregator(threading.Thread):
             self.request_latency._append(stats.request_start_time, request_latency)
             if request_latency > self.window_duration:
                logging.warning((
-                     f"request completed in {math.ceil(request_latency)} seconds, while aggregation_window is {int(self.window_duration)} "
-                     "seconds. Consider increasing aggregation_window to at least 2x your typical request latency."
+                     f"request completed in {math.ceil(request_latency)} seconds, while aggregation-window is {int(self.window_duration)} "
+                     "seconds. Consider increasing aggregation-window to at least 2x your typical request latency."
                   )
                )   
             self.request_timestamps._append(stats.request_start_time, stats.request_start_time)


### PR DESCRIPTION
This adds a warning for when requests complete in a time period longer than the aggregation window. If this is happening consistently, these requests will immediately drop out of the statistics for the run, which can result in no windowed statistics (except for the second in which each request returns a response).

Example of issue: 
![image](https://github.com/Azure/azure-openai-benchmark/assets/12974372/01821b46-0186-48a3-b033-4356d52b2794)

With warning:
![image](https://github.com/Azure/azure-openai-benchmark/assets/12974372/983db0e3-2e3b-40a0-a9f9-2b5c631b309c)
