### PR TITLE
Add tpr stats output, and periodic warning when gen_tpr < 90% of max_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ The tool supports four different shape profiles via command line option `--shape
 |`ttft_95th`|95th percentile of time in seconds from the beginning of the request until the first token was received.|yes|`0.130`|
 |`tbt_avg`|Average time in seconds between two consequitive generated tokens.|yes|`0.018`|
 |`tbt_95th`|95th percentail of time in seconds between two consequitive generated tokens.|yes|`0.021`|
+|`gen_tpr_10th`|90th percentile of tokens per response.|yes|`389`|
+|`gen_tpr_avg`|Average tokens per response.|yes|`509`|
+|`gen_tpr_90th`|90th percentile of tokens per response.|yes|`626`|
 |`e2e_avg`|Average end to end request time.|yes|`1.2`|
 |`e2e_95th`|95th percentile of end to end request time.|yes|`1.5`|
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Note: With the default prompting strategy, OpenAI models will typically return c
 |`ttft_95th`|95th percentile of time in seconds from the beginning of the request until the first token was received.|yes|`0.130`|
 |`tbt_avg`|Average time in seconds between two consequitive generated tokens.|yes|`0.018`|
 |`tbt_95th`|95th percentail of time in seconds between two consequitive generated tokens.|yes|`0.021`|
-|`gen_tpr_10th`|90th percentile of tokens per response.|yes|`389`|
-|`gen_tpr_avg`|Average tokens per response.|yes|`509`|
-|`gen_tpr_90th`|90th percentile of tokens per response.|yes|`626`|
+|`gen_tpr_10th`|10th percentile of number of generated tokens per model response.|yes|`389`|
+|`gen_tpr_avg`|Average number of generated tokens per model response.|yes|`509`|
+|`gen_tpr_90th`|90th percentile of number of generated tokens per model response.|yes|`626`|
 |`e2e_avg`|Average end to end request time.|yes|`1.2`|
 |`e2e_95th`|95th percentile of end to end request time.|yes|`1.5`|
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The tool supports four different shape profiles via command line option `--shape
 |`generation`|Represents workloads with larger generation and smaller contexts. For example, question answering.|500|1000|
 |`custom`|Allows specifying custom values for context size (`--context-tokens`) and max generation tokens (`--max-tokens`).|||  
 
+Note: With the default prompting strategy, OpenAI models will typically return completions of a max of 700-1200 tokens. If setting `max_tokens` above 750, be aware that the results for `rpm` may be higher, and `e2e` latency lower, than if the model was returning completions of size `max_tokens` in every response. Refer to the `gen_tpr` stats at the end of each run to see how many tokens were generated across responses.
+
 ### Output fields
 
 |field|description|sliding window|example|

--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -1,20 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import time
+import logging
+import math
 import os
+import sys
+import time
+from typing import Iterable, Iterator
+
 import aiohttp
 import wonderwords
-import math
-import logging
-from typing import Iterable, Iterator
-from .statsaggregator import _StatsAggregator
-from .oairequester import OAIRequester
-from .asynchttpexecuter import AsyncHTTPExecuter
-from .ratelimiting import RateLimiter, NoRateLimiter
-from .oaitokenizer import num_tokens_from_messages
 
-import sys
+from .asynchttpexecuter import AsyncHTTPExecuter
+from .oairequester import OAIRequester
+from .oaitokenizer import num_tokens_from_messages
+from .ratelimiting import NoRateLimiter, RateLimiter
+from .statsaggregator import _StatsAggregator
+
 
 class _RequestBuilder:
    """
@@ -122,6 +124,7 @@ def _run_load(request_builder: Iterable[dict],
    aggregator = _StatsAggregator(
       window_duration=aggregation_duration,
       dump_duration=1, 
+      expected_gen_tokens=request_builder.max_tokens,
       json_output=json_output)
    requester = OAIRequester(api_key, url, backoff=backoff)
 

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -123,6 +123,7 @@ class _StatsAggregator(threading.Thread):
             tokens_per_minute += context_per_minute
          if gen_per_minute != "n/a":
             tokens_per_minute += gen_per_minute
+         context_tpr_avg = int(np.sum(self.context_tokens._values()) / self.context_tokens._len()) if self.context_tokens._len() > 0 else "n/a"
          gen_tpr_avg = int(np.sum(self.generated_tokens._values()) / self.generated_tokens._len()) if self.generated_tokens._len() > 0 else "n/a"
          gen_tpr_10th = int(np.percentile(self.generated_tokens._values(), 10)) if self.generated_tokens._len() > 1 else "n/a"
          gen_tpr_90th = int(np.percentile(self.generated_tokens._values(), 90)) if self.generated_tokens._len() > 1 else "n/a"
@@ -143,7 +144,7 @@ class _StatsAggregator(threading.Thread):
             logging.warning(
                (
                   f"average tokens per response is {gen_tpr_avg}, compared to requested max_tokens of {self.expected_gen_tokens}."
-                  " this may mean measured rpm and e2e request latency are higher here than in real-world workloads"
+                  " this may mean measured rpm is higher and e2e request latency is faster than in real-world workloads"
                   " (tpm, ttft & tbt stats will still be accurate)."
                )
             )
@@ -172,6 +173,7 @@ class _StatsAggregator(threading.Thread):
                   "avg": tbt_avg,
                   "95th": tbt_95th,
                },
+               "context_tpr_avg": context_tpr_avg,
                "gen_tpr": {
                   "10th": gen_tpr_10th,
                   "avg": gen_tpr_avg,
@@ -184,7 +186,7 @@ class _StatsAggregator(threading.Thread):
             }
             print(json.dumps(j), flush=True)
          else:
-            print(f"{timestamp} rpm: {rpm:<5} requests: {self.requests_count:<5} failures: {self.failed_count:<4} throttled: {self.throttled_count:<4} tpm: {tokens_per_minute:<6} ttft_avg: {ttft_avg:<6} ttft_95th: {ttft_95th:<6} tbt_avg: {tbt_avg:<6} tbt_95th: {tbt_95th:<6} e2e_avg: {e2e_latency_avg:<6} e2e_95th: {e2e_latency_95th:<6} gen_tpr_10th {gen_tpr_10th:<4} gen_tpr_avg {gen_tpr_avg:<4} gen_tpr_90th {gen_tpr_90th:<4} util_avg: {util_avg:<6} util_95th: {util_95th:<6}", flush=True)
+            print(f"{timestamp} rpm: {rpm:<5} requests: {self.requests_count:<5} failures: {self.failed_count:<4} throttled: {self.throttled_count:<4} tpm: {tokens_per_minute:<6} ttft_avg: {ttft_avg:<6} ttft_95th: {ttft_95th:<6} tbt_avg: {tbt_avg:<6} tbt_95th: {tbt_95th:<6} e2e_avg: {e2e_latency_avg:<6} e2e_95th: {e2e_latency_95th:<6} context_tpr_avg {context_tpr_avg:<4} gen_tpr_10th {gen_tpr_10th:<4} gen_tpr_avg {gen_tpr_avg:<4} gen_tpr_90th {gen_tpr_90th:<4} util_avg: {util_avg:<6} util_95th: {util_95th:<6}", flush=True)
 
    def _slide_window(self):
       with self.lock:

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -142,8 +142,8 @@ class _StatsAggregator(threading.Thread):
          )) and gen_tpr_avg < 0.9 * self.expected_gen_tokens:
             logging.warning(
                (
-                  f"Average tokens per response is {gen_tpr_avg}, compared to requested max_tokens of {self.expected_gen_tokens}."
-                  " This may mean measured RPM and e2e request latency are higher here than in real-world workloads"
+                  f"average tokens per response is {gen_tpr_avg}, compared to requested max_tokens of {self.expected_gen_tokens}."
+                  " this may mean measured rpm and e2e request latency are higher here than in real-world workloads"
                   " (tpm, ttft & tbt stats will still be accurate)."
                )
             )


### PR DESCRIPTION
Periodically (every 10s) alerts users when the average number of generated tokens is less than 90% of max_tokens. This is important if users are using the tool to estimate total requests per second based on their real-world context/response sizes,  but the models are returning considerably shorter responses in testing (due to different/automated prompts).