### PR TITLE
Add dynamic aggregation window

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The tool supports four different shape profiles via command line option `--shape
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|
 |`util_95th`|95th percentile of deployment utilization percentage as reported by the service.|yes|`91.2%`|
 
+Note: Prior to the run reaching `aggregation-window` in elapsed time, sliding window stats will be calculated over the time elapsed since starting the test.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The tool supports four different shape profiles via command line option `--shape
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|
 |`util_95th`|95th percentile of deployment utilization percentage as reported by the service.|yes|`91.2%`|
 
-Note: Prior to the run reaching `aggregation-window` in elapsed time, sliding window stats will be calculated over the time elapsed since starting the test.
+Note: Prior to the benchmarking run reaching `aggregation-window` in elapsed time, all sliding window stats will be calculated over a dynamic window, equal to the time elapsed since starting the test. This ensures RPM/TPM stats are relatively accurate prior to the test reaching completion, including when a test ends early due to reaching the request limit.
 
 ## Contributing
 


### PR DESCRIPTION
Currently, all statistics are averaged over `aggregation-window` seconds, even when the test has not yet been running for that long. This means the RPM and TPM statistics will always start from zero and steadily increase to their correct values once the elapsed time has reached `aggregation-window` seconds, which can be confusing, and means it is difficult to diagnose any issues in configuration until the stats reach their correct values (which can be minutes later).

This PR fixes this by using a dynamic window size when calculating the windowed stats, which then reverts back to the original `aggregation-window` once the test has run for longer than it.