### PR TITLE
Added proxy parameter to support accessing through proxy.

### DIFF
--- a/benchmark/asynchttpexecuter.py
+++ b/benchmark/asynchttpexecuter.py
@@ -43,7 +43,7 @@ class AsyncHTTPExecuter:
         orig_sigterm_handler = signal.signal(signal.SIGTERM, self._terminate)
         # disable all TCP limits for highly parallel loads
         conn = aiohttp.TCPConnector(limit=0)
-        async with aiohttp.ClientSession(connector=conn) as session:
+        async with aiohttp.ClientSession(trust_env=True, connector=conn) as session:
             start_time = time.time()
             calls_made = 0
             request_tasks = set()


### PR DESCRIPTION
When accessing outbound traffic through a proxy server, a --proxy parameter has been added to configure the web proxy during benchmarking. You can added below content into launch.json for testing proxy server feature.

```json
{
    "version": "0.2.0",
    "configurations": [

        {
            "name": "Python Debugging: Module",
            "type": "debugpy",
            "request": "launch",
            "module": "benchmark.bench",
            "env": {
                "OPENAI_API_KEY": "<Azure OpenAI Key>"
            },
            "args": [
                "load", 
                "--requests", "1000", 
                "--deployment", "gpt-4.1", 
                "--rate", "60", 
                "--retry", 
                "exponential", "https://<AOAI resource name>.openai.azure.com/", 
                "--proxy", "http://<Proxy server name/IP>:<port>"
            ]
        }
    ]
}

```